### PR TITLE
fix: v3/files endpoint takes 'file' form argument

### DIFF
--- a/src/public_api/file/mod.rs
+++ b/src/public_api/file/mod.rs
@@ -44,7 +44,7 @@ impl VtClient {
             f.read_to_end(&mut buffer)?;
         }
         let form_data = Form::new().part(
-            "public_api.file",
+            "file",
             Part::bytes(buffer).file_name(file.to_owned()),
         );
         let url = format!("{}/files", &self.endpoint);


### PR DESCRIPTION
Hopefully I'm understanding the API correctly, but I get an malformed request when using the crate with file_scan, after changing the endpoint to 'file' as written in the API doc instead of 'public_api.file' it now seems to work properly.